### PR TITLE
Added .net6.0 & .net7.0 target frameworks & update to latest packages…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,14 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: "3.1.x"
+      - name: Setup .NET 6.0
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: "6.0.x"
+      - name: Setup .NET 7.0
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: "7.0.x"
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
       - name: Run tests

--- a/README.md
+++ b/README.md
@@ -53,7 +53,10 @@ foreach(var method in apiBrowseResponse.Result)
 ...
 using System.Net;
 ...
+// For .net48
 ServicePointManager.ServerCertificateValidationCallback += (sender, certificate, chain, sslPolicyErrors) => true;
+// For .net6.0 and greater
+Siemens.Simatic.S7.Webserver.API.Services.ServerCertificateCallback.CertificateCallback = (sender, cert, chain, sslPolicyErrors) => true;
 ```
 Of course you can also implement a check for the sender and so on.
 # WebApps

--- a/src/Webserver.API/Services/ApiServiceFactory.cs
+++ b/src/Webserver.API/Services/ApiServiceFactory.cs
@@ -129,6 +129,13 @@ namespace Siemens.Simatic.S7.Webserver.API.Services
             {
                 AllowAutoRedirect = connectionConfiguration.AllowAutoRedirect
             };
+#if NET6_0_OR_GREATER
+            // Ignoring SSL errors in net6.0 and greater
+            if (ServerCertificateCallback.CertificateCallback != null)
+            {
+                httpClientHandler.ServerCertificateCustomValidationCallback = ServerCertificateCallback.CertificateCallback;
+            }
+#endif
             HttpClient httpClient = new HttpClient(httpClientHandler);
             httpClient.DefaultRequestHeaders.ConnectionClose = connectionConfiguration.ConnectionClose;
             httpClient.BaseAddress = new Uri("https://" + connectionConfiguration.BaseAddress);
@@ -199,6 +206,13 @@ namespace Siemens.Simatic.S7.Webserver.API.Services
             {
                 AllowAutoRedirect = connectionConfiguration.AllowAutoRedirect
             };
+#if NET6_0_OR_GREATER
+            // Ignoring SSL errors in net6.0 and greater
+            if (ServerCertificateCallback.CertificateCallback != null)
+            {
+                httpClientHandler.ServerCertificateCustomValidationCallback = ServerCertificateCallback.CertificateCallback;
+            }
+#endif
             HttpClient httpClient = new HttpClient(httpClientHandler);
             httpClient.DefaultRequestHeaders.ConnectionClose = connectionConfiguration.ConnectionClose;
             httpClient.BaseAddress = new Uri("https://" + connectionConfiguration.BaseAddress);

--- a/src/Webserver.API/Services/ServerCertificateCallback.cs
+++ b/src/Webserver.API/Services/ServerCertificateCallback.cs
@@ -1,0 +1,28 @@
+// Copyright (c) 2021, Siemens AG
+//
+// SPDX-License-Identifier: MIT
+
+#if NET6_0_OR_GREATER
+using System;
+using System.Net.Http;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Siemens.Simatic.S7.Webserver.API.Services
+{
+    /// <summary>
+    /// Provides access to custom server certificate callback for handling SSL errors.
+    /// </summary>
+    public class ServerCertificateCallback
+    {        
+        /// <summary>
+        /// Gets or sets custom server certificate callback.
+        /// </summary>
+       public static Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool>? CertificateCallback
+        {
+            get;
+            set;
+        }    
+    }
+}
+#endif

--- a/src/Webserver.API/Webserver.API.csproj
+++ b/src/Webserver.API/Webserver.API.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net48</TargetFrameworks>
+    <TargetFrameworks>net48;netstandard2.0;net6.0;net7.0</TargetFrameworks>
     <AssemblyName>Siemens.Simatic.S7.Webserver.API</AssemblyName>
     <RootNamespace>Siemens.Simatic.S7.Webserver.API</RootNamespace>
     <Platforms>AnyCPU</Platforms>
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="MimeMapping" Version="1.0.1.37" />
+    <PackageReference Include="MimeMapping" Version="1.0.1.50" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>

--- a/tests/Webserver.API.UnitTests/Webserver.Api.UnitTests.csproj
+++ b/tests/Webserver.API.UnitTests/Webserver.Api.UnitTests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFrameworks>net48;net6.0;net7.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <AssemblyName>Webserver.API.UnitTests</AssemblyName>
     <RootNamespace>Webserver.API.UnitTests</RootNamespace>
@@ -13,7 +13,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -21,12 +21,12 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="MimeMapping" Version="1.0.1.37" />
-    <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="nunit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
-    <PackageReference Include="RichardSzalay.MockHttp" Version="4.0.0" />
+    <PackageReference Include="MimeMapping" Version="1.0.1.50" />
+    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="nunit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
     <PackageReference Include="System.Web.Http.Common" Version="4.0.20126.16343" />
   </ItemGroup>
 


### PR DESCRIPTION
…. (#23)

* added .net6.0 target, package update
* now targeting both net6.0 and net7.0. Update to latest nugets.
* adding provisioning of net7.0 and net6.0 in ci pipeline
* added wrapper for handling security certificate for .net6.0 and greater